### PR TITLE
Fix body overflow hidden when navigating by navbar

### DIFF
--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -31,6 +31,7 @@ const Navbar: React.FC = () => {
   useEffect(() => {
     setIsMenuOpen(false);
     setIsDropdownOpen(false);
+    document.body.style.overflow = 'initial';
   }, [location]);
 
   function openMenu() {


### PR DESCRIPTION
Ao navegar entre páginas pela "navbar" na versão mobile o _body_ da página continua com _overflow hidden_, forçando o recarregamento da página.