### PR TITLE
Add ScrollToTop component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,12 @@ import Footer from './components/Footer';
 import Navbar from './components/Navbar';
 
 import Routes from './routes';
+import ScrollToTop from './components/ScrollToTop';
 
 function App() {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <Navbar />
       <Routes />
       <Footer />

--- a/src/components/ScrollToTop/index.tsx
+++ b/src/components/ScrollToTop/index.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
By default when navigating using `react-router-dom` link component the scroll position is preserved meaning that if we're in the end of the page, we'll still there after changing the page. This component allow us to go to the top of the page automatically after navigating.

This approach follows the same as provided in the react-router-dom docs ([Scroll restoration](https://reactrouter.com/web/guides/scroll-restoration))