### PR TITLE
Remove pandemic references and re-enable courses

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command = "npm run build"
-  publish = "dist"
+  command = "yarn install && yarn build"
+  publish = "build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command = "yarn install && yarn build"
-  publish = "build"
+  command = "npm run build"
+  publish = "dist"

--- a/src/pages/public/Home/index.tsx
+++ b/src/pages/public/Home/index.tsx
@@ -115,8 +115,6 @@ const Home: React.FC = () => {
             description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Eros, lectus aenean aliquam duis dictum nec et."
             linkTo="/cursos/ingles"
             inClass
-            disabled
-            disabledMotivation="Devido a pandemia não é possível a realização de aulas presenciais."
           />
 
           <CourseCard
@@ -125,8 +123,6 @@ const Home: React.FC = () => {
             description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Eros, lectus aenean aliquam duis dictum nec et."
             linkTo="/cursos/espanhol"
             inClass
-            disabled
-            disabledMotivation="Devido a pandemia não é possível a realização de aulas presenciais."
           />
         </div>
       </Courses>


### PR DESCRIPTION
## Summary
- Removed pandemic-related `disabled` and `disabledMotivation` props from English and Spanish course cards
- In-class courses are now enabled again on the homepage

## Test plan
- [ ] Verify English and Spanish course cards are clickable on the homepage
- [ ] Confirm no remaining pandemic references in the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)